### PR TITLE
Update public GitHub profile page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 ## Rebilly products
 - [Billing &mdash; a subscription billing platform](https://www.rebilly.com/docs/content/billing/)
-- [Payments &mdash; a payments orchestration platform](https://www.rebilly.com/docs/content/billing/)
+- [Payments &mdash; a payments orchestration platform](https://www.rebilly.com/docs/content/payments/)
 - [Risk &mdash; a risk management platform](https://www.rebilly.com/docs/content/risk-management/)
 
 ## Contact us

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,14 @@
-## Hi there 👋
+<a href="https://www.rebilly.com/docs/"> <img src="https://github.com/Rebilly/website/blob/main/images/rebillySocial.png" alt="Horse jumping" height="400" /> </a>
+
+## Rebilly products
+- [Billing &mdash; a subscription billing platform](https://www.rebilly.com/docs/content/billing/)
+- [Payments &mdash; a payments orchestration platform](https://www.rebilly.com/docs/content/billing/)
+- [Risk &mdash; a risk management platform](https://www.rebilly.com/docs/content/risk-management/)
+
+## Contact us
+- [Get a demo](https://www.rebilly.com/get-a-demo/)
+- [Contact sales and support](https://www.rebilly.com/contact/)
+- [Careers](https://www.rebilly.com/careers/)
 
 <!--
 


### PR DESCRIPTION
From looking at other companies public profiles, these generally don't have much, or any, text. I though that it might be useful to provide links to our product documentation and contact links.

I also think that it would be good to do the following (I don't have admin rights):
- Pin popular public Rebilly repositories to this profile page &mdash; [pin items to your profile](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/pinning-items-to-your-profile).
- Use the [Rebilly logo](https://github.com/Rebilly/website/blob/main/images/about/rebillyIcon.png) for the organization GitHub image.